### PR TITLE
Lime light off

### DIFF
--- a/src/main/java/frc/robot/commands/C_Track.java
+++ b/src/main/java/frc/robot/commands/C_Track.java
@@ -8,6 +8,8 @@
 package frc.robot.commands;
 
 import org.frcteam2910.common.math.Vector2;
+import org.frcteam2910.common.robot.drivers.Limelight;
+
 import java.util.function.DoubleSupplier;
 
 import edu.wpi.first.wpilibj.controller.PIDController;
@@ -50,6 +52,7 @@ public class C_Track extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
+    vision.setLEDMode(Vision.LED_ON);
   }
 
   // Called every time the scheduler runs while the command is scheduled.
@@ -61,6 +64,7 @@ public class C_Track extends CommandBase {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
+    vision.setLEDMode(Vision.LED_OFF);
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/drivers/Vision.java
+++ b/src/main/java/frc/robot/drivers/Vision.java
@@ -55,6 +55,7 @@ public class Vision {
     ts = visionTable.getEntry("ts");
     camtran = visionTable.getEntry("camtran");
     setMode(CAMERA_DEFAULT_MODE, LED_DEFAULT_MODE, DEFAULT_PIPELINE);
+    setLEDMode(Vision.LED_OFF);
   }
 
   public void updateTelemetry() {


### PR DESCRIPTION
the LimeLight off sets the limelight to turn off when we are not tracking but if you are tracking a target the limelight light turns on.